### PR TITLE
chore: Upgrade to ktls v3

### DIFF
--- a/crates/fluke-tls-sample/Cargo.toml
+++ b/crates/fluke-tls-sample/Cargo.toml
@@ -11,13 +11,13 @@ fluke = { path = "../fluke" }
 rcgen = "0.10.0"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-rustls = { version = "0.20.9", features = ["secret_extraction"] }
+rustls = { version = "0.21.7", features = ["secret_extraction"] }
 tokio = { version = "1.28.2", features = ["full"] }
-tokio-rustls = "0.23.4"
+tokio-rustls = "0.24.1"
 http = "0.2.9"
 pretty-hex = "0.3.0"
-fluke-maybe-uring = { version = "0.1.1", path = "../fluke-maybe-uring" }
+fluke-maybe-uring = { version = "0.1.1", path = "../fluke-maybe-uring", features = ["net"] }
 socket2 = "0.5.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-ktls = "2.0.0"
+ktls = "3.0.0"


### PR DESCRIPTION
Notably, this bumps rustls and tokio-rustls. 3.0.0 was yanked for a while, and now 3.0.2 is a version we can depend on.

See https://github.com/hapsoc/ktls/blob/main/CHANGELOG.md#300-2023-06-14-yanked