### PR TITLE
fix: Treat WINDOW_UPDATE on idle stream as a protocol error

### DIFF
--- a/crates/fluke-hpack/src/decoder.rs
+++ b/crates/fluke-hpack/src/decoder.rs
@@ -746,7 +746,7 @@ mod tests {
         {
             let full_string: Vec<u8> = (0u8..200).collect();
             let mut encoded = encode_integer(full_string.len(), 7);
-            encoded.extend(full_string.clone().into_iter());
+            encoded.extend(full_string.clone());
 
             assert_eq!(
                 (Cow::Owned(full_string), encoded.len()),
@@ -756,7 +756,7 @@ mod tests {
         {
             let full_string: Vec<u8> = (0u8..127).collect();
             let mut encoded = encode_integer(full_string.len(), 7);
-            encoded.extend(full_string.clone().into_iter());
+            encoded.extend(full_string.clone());
 
             assert_eq!(
                 (Cow::Owned(full_string), encoded.len()),

--- a/crates/fluke-hpack/src/encoder.rs
+++ b/crates/fluke-hpack/src/encoder.rs
@@ -433,7 +433,7 @@ mod tests {
         {
             let mut encoder: Encoder = Encoder::new();
             // `:method` is in the static table, but only for GET and POST
-            let headers = vec![(b":method", b"PUT")];
+            let headers = [(b":method", b"PUT")];
 
             let result = encoder.encode(headers.iter().map(|h| (&h.0[..], &h.1[..])));
 

--- a/crates/fluke-hpack/src/huffman.rs
+++ b/crates/fluke-hpack/src/huffman.rs
@@ -61,9 +61,7 @@ impl HuffmanDecoder {
         let mut eos_codepoint: Option<(u32, u8)> = None;
 
         for (symbol, &(code, code_len)) in table.iter().enumerate() {
-            decoder_table
-                .entry(code_len)
-                .or_default();
+            decoder_table.entry(code_len).or_default();
             let subtable = decoder_table.get_mut(&code_len).unwrap();
             let huff_symbol = HuffmanCodeSymbol::new(symbol);
             if let HuffmanCodeSymbol::EndOfString = huff_symbol {
@@ -495,7 +493,7 @@ mod tests {
         let expected_result = to_expected_bit_result(&[0, 0, 0, 0, 1, 0, 1, 0]);
 
         let mut res: Vec<bool> = Vec::new();
-        for b in BitIterator::new(vec![10u8].iter()) {
+        for b in BitIterator::new([10u8].iter()) {
             res.push(b);
         }
 
@@ -510,7 +508,7 @@ mod tests {
         ]);
 
         let mut res: Vec<bool> = Vec::new();
-        for b in BitIterator::new(vec![10u8, 255, 128, 1, 0, 170].iter()) {
+        for b in BitIterator::new([10u8, 255, 128, 1, 0, 170].iter()) {
             res.push(b);
         }
 

--- a/crates/fluke/src/h2/encode.rs
+++ b/crates/fluke/src/h2/encode.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 use crate::{h1::body::BodyWriteMode, Encoder, Response};
 use fluke_buffet::{Piece, Roll};
 
-use super::parse::{KnownErrorCode, StreamId};
+use super::{parse::{KnownErrorCode, StreamId}, H2ConnectionError};
 
 pub(crate) enum H2ConnEvent {
     Ping(Roll),
@@ -16,9 +16,8 @@ pub(crate) enum H2ConnEvent {
         new_max_header_table_size: u32,
     },
     GoAway {
-        error_code: KnownErrorCode,
+        err: H2ConnectionError,
         last_stream_id: StreamId,
-        additional_debug_data: Piece,
     },
     RstStream {
         stream_id: StreamId,

--- a/crates/fluke/src/h2/server.rs
+++ b/crates/fluke/src/h2/server.rs
@@ -385,7 +385,7 @@ impl<D: ServerDriver + 'static> H2ReadContext<D> {
             // TODO: there might be optimizations to be done for `Data` frames later
             // on, but for now, let's unconditionally read the payload (if it's not
             // empty).
-            let mut payload: Roll = if frame.len == 0 {
+            let payload: Roll = if frame.len == 0 {
                 Roll::empty()
             } else {
                 let payload_roll;
@@ -409,307 +409,306 @@ impl<D: ServerDriver + 'static> H2ReadContext<D> {
                 payload_roll
             };
 
-            match self.continuation_state {
-                ContinuationState::Idle => {
-                    match frame.frame_type {
-                        FrameType::Data(flags) => {
-                            if flags.contains(DataFlags::Padded) {
-                                if payload.is_empty() {
-                                    todo!("handle connection error: padded data frame, but no padding length");
-                                }
+            self.process_frame(frame, payload).await?;
+        }
+    }
 
-                                let padding_length_roll;
-                                (padding_length_roll, payload) = payload.split_at(1);
-                                let padding_length = padding_length_roll[0] as usize;
-                                if payload.len() < padding_length {
-                                    todo!("handle connection error: padded headers frame, but not enough padding");
-                                }
-
-                                let at = payload.len() - padding_length;
-                                (payload, _) = payload.split_at(at);
+    async fn process_frame(&mut self, frame: Frame, mut payload: Roll) -> eyre::Result<()> {
+        match self.continuation_state {
+            ContinuationState::Idle => {
+                match frame.frame_type {
+                    FrameType::Data(flags) => {
+                        if flags.contains(DataFlags::Padded) {
+                            if payload.is_empty() {
+                                todo!("handle connection error: padded data frame, but no padding length");
                             }
 
-                            let body_tx = {
-                                let stage = self
-                                    .state
-                                    .streams
-                                    .get_mut(&frame.stream_id)
-                                    // TODO: proper error handling (connection error)
-                                    .expect("received data for unknown stream");
-                                match stage {
-                                    StreamStage::Headers(_) => {
-                                        // TODO: proper error handling (stream error)
-                                        panic!("expected headers, received data")
-                                    }
-                                    StreamStage::Trailers(..) => {
-                                        // TODO: proper error handling (stream error)
-                                        panic!("expected trailers, received data")
-                                    }
-                                    StreamStage::Body(tx) => {
-                                        // TODO: we can get rid of that clone sometimes
-                                        let tx = tx.clone();
-                                        if flags.contains(DataFlags::EndStream) {
-                                            *stage = StreamStage::Done;
-                                        }
-                                        tx
-                                    }
-                                    StreamStage::Done => {
-                                        // TODO: proper error handling (stream error)
-                                        panic!("received data for stream after completion");
-                                    }
-                                }
-                            };
-
-                            if body_tx
-                                .send(Ok(PieceOrTrailers::Piece(payload.into())))
-                                .await
-                                .is_err()
-                            {
-                                warn!(
-                                    "TODO: The body is being ignored, we should reset the stream"
-                                );
+                            let padding_length_roll;
+                            (padding_length_roll, payload) = payload.split_at(1);
+                            let padding_length = padding_length_roll[0] as usize;
+                            if payload.len() < padding_length {
+                                todo!("handle connection error: padded headers frame, but not enough padding");
                             }
+
+                            let at = payload.len() - padding_length;
+                            (payload, _) = payload.split_at(at);
                         }
-                        FrameType::Headers(flags) => {
-                            // TODO: if we're shutting down, ignore streams higher
-                            // than the last one we accepted.
 
-                            if frame.stream_id.is_server_initiated() {
-                                self.send_goaway(H2ConnectionError::ClientSidShouldBeOdd)
-                                    .await;
-                                continue;
-                            }
-
-                            if frame.stream_id < self.state.last_stream_id {
-                                self.send_goaway(H2ConnectionError::ClientSidShouldBeIncreasing)
-                                    .await;
-                            }
-                            self.state.last_stream_id = frame.stream_id;
-
-                            let padding_length = if flags.contains(HeadersFlags::Padded) {
-                                if payload.is_empty() {
-                                    self.send_goaway(H2ConnectionError::PaddedFrameEmpty).await;
-                                    continue;
+                        let body_tx = {
+                            let stage = self
+                                .state
+                                .streams
+                                .get_mut(&frame.stream_id)
+                                // TODO: proper error handling (connection error)
+                                .expect("received data for unknown stream");
+                            match stage {
+                                StreamStage::Headers(_) => {
+                                    // TODO: proper error handling (stream error)
+                                    panic!("expected headers, received data")
                                 }
-
-                                let padding_length_roll;
-                                (padding_length_roll, payload) = payload.split_at(1);
-                                padding_length_roll[0] as usize
-                            } else {
-                                0
-                            };
-
-                            if flags.contains(HeadersFlags::Priority) {
-                                let pri_spec;
-                                (payload, pri_spec) = PrioritySpec::parse(payload)
-                                    .finish()
-                                    .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
-                                debug!(exclusive = %pri_spec.exclusive, stream_dependency = ?pri_spec.stream_dependency, weight = %pri_spec.weight, "received priority, exclusive");
-
-                                if pri_spec.stream_dependency == frame.stream_id {
-                                    self.send_goaway(H2ConnectionError::HeadersInvalidPriority {
-                                        stream_id: frame.stream_id,
-                                    })
-                                    .await;
-                                    continue;
+                                StreamStage::Trailers(..) => {
+                                    // TODO: proper error handling (stream error)
+                                    panic!("expected trailers, received data")
                                 }
-                            }
-
-                            if padding_length > 0 {
-                                if payload.len() < padding_length {
-                                    self.send_goaway(H2ConnectionError::PaddedFrameTooShort)
-                                        .await;
-                                }
-
-                                let at = payload.len() - padding_length;
-                                (payload, _) = payload.split_at(at);
-                            }
-
-                            let headers_data = HeadersData {
-                                end_stream: flags.contains(HeadersFlags::EndStream),
-                                fragments: smallvec![payload],
-                            };
-
-                            match self.state.streams.get_mut(&frame.stream_id) {
-                                Some(stage) => {
-                                    debug!("Receiving trailers for stream {}", frame.stream_id);
-
-                                    if !flags.contains(HeadersFlags::EndStream) {
-                                        todo!(
-                                            "handle connection error: trailers must have EndStream, this just looks like duplicate headers for stream {}",
-                                            frame.stream_id
-                                        );
+                                StreamStage::Body(tx) => {
+                                    // TODO: we can get rid of that clone sometimes
+                                    let tx = tx.clone();
+                                    if flags.contains(DataFlags::EndStream) {
+                                        *stage = StreamStage::Done;
                                     }
-
-                                    let prev_stage = std::mem::replace(stage, StreamStage::Done);
-                                    match prev_stage {
-                                        StreamStage::Body(body_tx) => {
-                                            *stage = StreamStage::Trailers(body_tx, headers_data);
-                                        }
-                                        // FIXME: that's a connection error
-                                        _ => unreachable!(),
-                                    }
+                                    tx
                                 }
-                                None => {
-                                    debug!("Receiving headers for stream {}", frame.stream_id);
-                                    self.state.streams.insert(
-                                        frame.stream_id,
-                                        StreamStage::Headers(headers_data),
-                                    );
+                                StreamStage::Done => {
+                                    // TODO: proper error handling (stream error)
+                                    panic!("received data for stream after completion");
                                 }
                             }
+                        };
 
-                            if flags.contains(HeadersFlags::EndHeaders) {
-                                self.end_headers(frame.stream_id).await;
-                            } else {
-                                debug!(
-                                    "expecting more headers/trailers for stream {}",
-                                    frame.stream_id
-                                );
-                                self.continuation_state =
-                                    ContinuationState::ContinuingHeaders(frame.stream_id);
-                            }
+                        if body_tx
+                            .send(Ok(PieceOrTrailers::Piece(payload.into())))
+                            .await
+                            .is_err()
+                        {
+                            warn!("TODO: The body is being ignored, we should reset the stream");
                         }
-                        FrameType::Priority => {
-                            let pri_spec = match PrioritySpec::parse(payload) {
-                                Ok((_rest, pri_spec)) => pri_spec,
-                                Err(e) => {
-                                    todo!("handle connection error: invalid priority frame {e}")
-                                }
-                            };
-                            debug!(?pri_spec, "received priority frame");
+                    }
+                    FrameType::Headers(flags) => {
+                        // TODO: if we're shutting down, ignore streams higher
+                        // than the last one we accepted.
+
+                        if frame.stream_id.is_server_initiated() {
+                            self.send_goaway(H2ConnectionError::ClientSidShouldBeOdd)
+                                .await;
+                            return Ok(());
+                        }
+
+                        if frame.stream_id < self.state.last_stream_id {
+                            self.send_goaway(H2ConnectionError::ClientSidShouldBeIncreasing)
+                                .await;
+                        }
+                        self.state.last_stream_id = frame.stream_id;
+
+                        let padding_length = if flags.contains(HeadersFlags::Padded) {
+                            if payload.is_empty() {
+                                self.send_goaway(H2ConnectionError::PaddedFrameEmpty).await;
+                                return Ok(());
+                            }
+
+                            let padding_length_roll;
+                            (padding_length_roll, payload) = payload.split_at(1);
+                            padding_length_roll[0] as usize
+                        } else {
+                            0
+                        };
+
+                        if flags.contains(HeadersFlags::Priority) {
+                            let pri_spec;
+                            (payload, pri_spec) = PrioritySpec::parse(payload)
+                                .finish()
+                                .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
+                            debug!(exclusive = %pri_spec.exclusive, stream_dependency = ?pri_spec.stream_dependency, weight = %pri_spec.weight, "received priority, exclusive");
 
                             if pri_spec.stream_dependency == frame.stream_id {
                                 self.send_goaway(H2ConnectionError::HeadersInvalidPriority {
                                     stream_id: frame.stream_id,
                                 })
                                 .await;
-                                continue;
+                                return Ok(());
                             }
                         }
-                        FrameType::RstStream => todo!("implement RstStream"),
-                        FrameType::Settings(s) => {
-                            if s.contains(SettingsFlags::Ack) {
-                                debug!("Peer has acknowledged our settings, cool");
-                            } else {
-                                // TODO: actually apply settings
-                                let (_, settings) = Settings::parse(payload)
-                                    .finish()
-                                    .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
-                                let new_max_header_table_size = settings.header_table_size;
-                                debug!(?settings, "Received settings");
-                                self.state.peer_settings = settings;
 
-                                if self
-                                    .ev_tx
-                                    .send(H2ConnEvent::AcknowledgeSettings {
-                                        new_max_header_table_size,
-                                    })
-                                    .await
-                                    .is_err()
-                                {
-                                    return Err(eyre::eyre!(
-                                        "could not send H2 acknowledge settings event"
-                                    ));
+                        if padding_length > 0 {
+                            if payload.len() < padding_length {
+                                self.send_goaway(H2ConnectionError::PaddedFrameTooShort)
+                                    .await;
+                            }
+
+                            let at = payload.len() - padding_length;
+                            (payload, _) = payload.split_at(at);
+                        }
+
+                        let headers_data = HeadersData {
+                            end_stream: flags.contains(HeadersFlags::EndStream),
+                            fragments: smallvec![payload],
+                        };
+
+                        match self.state.streams.get_mut(&frame.stream_id) {
+                            Some(stage) => {
+                                debug!("Receiving trailers for stream {}", frame.stream_id);
+
+                                if !flags.contains(HeadersFlags::EndStream) {
+                                    todo!(
+                                            "handle connection error: trailers must have EndStream, this just looks like duplicate headers for stream {}",
+                                            frame.stream_id
+                                        );
+                                }
+
+                                let prev_stage = std::mem::replace(stage, StreamStage::Done);
+                                match prev_stage {
+                                    StreamStage::Body(body_tx) => {
+                                        *stage = StreamStage::Trailers(body_tx, headers_data);
+                                    }
+                                    // FIXME: that's a connection error
+                                    _ => unreachable!(),
                                 }
                             }
-                        }
-                        FrameType::PushPromise => {
-                            self.send_goaway(H2ConnectionError::ClientSentPushPromise)
-                                .await;
-                            continue;
-                        }
-                        FrameType::Ping(flags) => {
-                            if frame.stream_id != StreamId::CONNECTION {
-                                todo!(
-                                    "handle connection error: ping frame with non-zero stream id"
-                                );
-                            }
-
-                            if frame.len != 8 {
-                                todo!("handle connection error: ping frame with invalid length");
-                            }
-
-                            if flags.contains(PingFlags::Ack) {
-                                // TODO: check that payload matches the one we sent?
-
-                                debug!("received ping ack");
-                                continue;
-                            }
-
-                            if self.ev_tx.send(H2ConnEvent::Ping(payload)).await.is_err() {
-                                return Err(eyre::eyre!("could not send H2 ping event"));
+                            None => {
+                                debug!("Receiving headers for stream {}", frame.stream_id);
+                                self.state
+                                    .streams
+                                    .insert(frame.stream_id, StreamStage::Headers(headers_data));
                             }
                         }
-                        FrameType::GoAway => todo!(),
-                        FrameType::WindowUpdate => {
-                            debug!("ignoring window update");
+
+                        if flags.contains(HeadersFlags::EndHeaders) {
+                            self.end_headers(frame.stream_id).await;
+                        } else {
+                            debug!(
+                                "expecting more headers/trailers for stream {}",
+                                frame.stream_id
+                            );
+                            self.continuation_state =
+                                ContinuationState::ContinuingHeaders(frame.stream_id);
                         }
-                        FrameType::Continuation(_flags) => {
-                            self.send_goaway(H2ConnectionError::UnexpectedContinuationFrame {
+                    }
+                    FrameType::Priority => {
+                        let pri_spec = match PrioritySpec::parse(payload) {
+                            Ok((_rest, pri_spec)) => pri_spec,
+                            Err(e) => {
+                                todo!("handle connection error: invalid priority frame {e}")
+                            }
+                        };
+                        debug!(?pri_spec, "received priority frame");
+
+                        if pri_spec.stream_dependency == frame.stream_id {
+                            self.send_goaway(H2ConnectionError::HeadersInvalidPriority {
                                 stream_id: frame.stream_id,
                             })
                             .await;
+                            return Ok(());
                         }
-                        FrameType::Unknown(ft) => {
-                            trace!(
-                                "ignoring unknown frame with type 0x{:x}, flags 0x{:x}",
-                                ft.ty,
-                                ft.flags
+                    }
+                    FrameType::RstStream => todo!("implement RstStream"),
+                    FrameType::Settings(s) => {
+                        if s.contains(SettingsFlags::Ack) {
+                            debug!("Peer has acknowledged our settings, cool");
+                        } else {
+                            // TODO: actually apply settings
+                            let (_, settings) = Settings::parse(payload)
+                                .finish()
+                                .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
+                            let new_max_header_table_size = settings.header_table_size;
+                            debug!(?settings, "Received settings");
+                            self.state.peer_settings = settings;
+
+                            if self
+                                .ev_tx
+                                .send(H2ConnEvent::AcknowledgeSettings {
+                                    new_max_header_table_size,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                return Err(eyre::eyre!(
+                                    "could not send H2 acknowledge settings event"
+                                ));
+                            }
+                        }
+                    }
+                    FrameType::PushPromise => {
+                        self.send_goaway(H2ConnectionError::ClientSentPushPromise)
+                            .await;
+                        return Ok(());
+                    }
+                    FrameType::Ping(flags) => {
+                        if frame.stream_id != StreamId::CONNECTION {
+                            todo!("handle connection error: ping frame with non-zero stream id");
+                        }
+
+                        if frame.len != 8 {
+                            todo!("handle connection error: ping frame with invalid length");
+                        }
+
+                        if flags.contains(PingFlags::Ack) {
+                            // TODO: check that payload matches the one we sent?
+
+                            debug!("received ping ack");
+                            return Ok(());
+                        }
+
+                        if self.ev_tx.send(H2ConnEvent::Ping(payload)).await.is_err() {
+                            return Err(eyre::eyre!("could not send H2 ping event"));
+                        }
+                    }
+                    FrameType::GoAway => todo!(),
+                    FrameType::WindowUpdate => {
+                        debug!("ignoring window update");
+                    }
+                    FrameType::Continuation(_flags) => {
+                        self.send_goaway(H2ConnectionError::UnexpectedContinuationFrame {
+                            stream_id: frame.stream_id,
+                        })
+                        .await;
+                    }
+                    FrameType::Unknown(ft) => {
+                        trace!(
+                            "ignoring unknown frame with type 0x{:x}, flags 0x{:x}",
+                            ft.ty,
+                            ft.flags
+                        );
+                    }
+                }
+            }
+            ContinuationState::ContinuingHeaders(expected_stream_id) => {
+                match frame.frame_type {
+                    FrameType::Continuation(flags) => {
+                        if frame.stream_id != expected_stream_id {
+                            self.send_goaway(H2ConnectionError::ExpectedContinuationForStream {
+                                stream_id: expected_stream_id,
+                                continuation_stream_id: frame.stream_id,
+                            })
+                            .await;
+                            return Ok(());
+                        }
+
+                        // unwrap rationale: we just checked that this is a
+                        // continuation of a stream we've already learned about.
+                        let ss = self.state.streams.get_mut(&frame.stream_id).unwrap();
+                        match ss {
+                            StreamStage::Headers(data) | StreamStage::Trailers(_, data) => {
+                                data.fragments.push(payload);
+                            }
+                            _ => {
+                                // FIXME: store `HeadersData` in
+                                // `ContinuationState` directly so this
+                                // branch doesn't even exist.
+                                unreachable!()
+                            }
+                        }
+
+                        if flags.contains(ContinuationFlags::EndHeaders) {
+                            self.end_headers(frame.stream_id).await;
+                        } else {
+                            debug!(
+                                "expecting more headers/trailers for stream {}",
+                                frame.stream_id
                             );
                         }
                     }
-                }
-                ContinuationState::ContinuingHeaders(expected_stream_id) => {
-                    match frame.frame_type {
-                        FrameType::Continuation(flags) => {
-                            if frame.stream_id != expected_stream_id {
-                                self.send_goaway(
-                                    H2ConnectionError::ExpectedContinuationForStream {
-                                        stream_id: expected_stream_id,
-                                        continuation_stream_id: frame.stream_id,
-                                    },
-                                )
-                                .await;
-                                continue;
-                            }
-
-                            // unwrap rationale: we just checked that this is a
-                            // continuation of a stream we've already learned about.
-                            let ss = self.state.streams.get_mut(&frame.stream_id).unwrap();
-                            match ss {
-                                StreamStage::Headers(data) | StreamStage::Trailers(_, data) => {
-                                    data.fragments.push(payload);
-                                }
-                                _ => {
-                                    // FIXME: store `HeadersData` in
-                                    // `ContinuationState` directly so this
-                                    // branch doesn't even exist.
-                                    unreachable!()
-                                }
-                            }
-
-                            if flags.contains(ContinuationFlags::EndHeaders) {
-                                self.end_headers(frame.stream_id).await;
-                            } else {
-                                debug!(
-                                    "expecting more headers/trailers for stream {}",
-                                    frame.stream_id
-                                );
-                            }
-                        }
-                        other => {
-                            self.send_goaway(H2ConnectionError::ExpectedContinuationFrame {
-                                stream_id: expected_stream_id,
-                                frame_type: other,
-                            })
-                            .await;
-                            continue;
-                        }
+                    other => {
+                        self.send_goaway(H2ConnectionError::ExpectedContinuationFrame {
+                            stream_id: expected_stream_id,
+                            frame_type: other,
+                        })
+                        .await;
+                        return Ok(());
                     }
                 }
             }
         }
+
+        Ok(())
     }
 
     async fn send_goaway(&self, e: H2ConnectionError) {

--- a/crates/fluke/src/h2/server.rs
+++ b/crates/fluke/src/h2/server.rs
@@ -413,301 +413,321 @@ impl<D: ServerDriver + 'static> H2ReadContext<D> {
         }
     }
 
-    async fn process_frame(&mut self, frame: Frame, mut payload: Roll) -> eyre::Result<()> {
+    async fn process_frame(&mut self, frame: Frame, payload: Roll) -> eyre::Result<()> {
         match self.continuation_state {
-            ContinuationState::Idle => {
-                match frame.frame_type {
-                    FrameType::Data(flags) => {
-                        if flags.contains(DataFlags::Padded) {
-                            if payload.is_empty() {
-                                todo!("handle connection error: padded data frame, but no padding length");
-                            }
+            ContinuationState::Idle => self.process_idle_frame(frame, payload).await,
+            ContinuationState::ContinuingHeaders(expected_stream_id) => {
+                self.process_continuation_frame(frame, payload, expected_stream_id)
+                    .await
+            }
+        }
+    }
 
-                            let padding_length_roll;
-                            (padding_length_roll, payload) = payload.split_at(1);
-                            let padding_length = padding_length_roll[0] as usize;
-                            if payload.len() < padding_length {
-                                todo!("handle connection error: padded headers frame, but not enough padding");
-                            }
+    async fn process_idle_frame(&mut self, frame: Frame, mut payload: Roll) -> eyre::Result<()> {
+        match frame.frame_type {
+            FrameType::Data(flags) => {
+                if flags.contains(DataFlags::Padded) {
+                    if payload.is_empty() {
+                        todo!("handle connection error: padded data frame, but no padding length");
+                    }
 
-                            let at = payload.len() - padding_length;
-                            (payload, _) = payload.split_at(at);
+                    let padding_length_roll;
+                    (padding_length_roll, payload) = payload.split_at(1);
+                    let padding_length = padding_length_roll[0] as usize;
+                    if payload.len() < padding_length {
+                        todo!(
+                            "handle connection error: padded headers frame, but not enough padding"
+                        );
+                    }
+
+                    let at = payload.len() - padding_length;
+                    (payload, _) = payload.split_at(at);
+                }
+
+                let body_tx = {
+                    let stage = self
+                        .state
+                        .streams
+                        .get_mut(&frame.stream_id)
+                        // TODO: proper error handling (connection error)
+                        .expect("received data for unknown stream");
+                    match stage {
+                        StreamStage::Headers(_) => {
+                            // TODO: proper error handling (stream error)
+                            panic!("expected headers, received data")
                         }
-
-                        let body_tx = {
-                            let stage = self
-                                .state
-                                .streams
-                                .get_mut(&frame.stream_id)
-                                // TODO: proper error handling (connection error)
-                                .expect("received data for unknown stream");
-                            match stage {
-                                StreamStage::Headers(_) => {
-                                    // TODO: proper error handling (stream error)
-                                    panic!("expected headers, received data")
-                                }
-                                StreamStage::Trailers(..) => {
-                                    // TODO: proper error handling (stream error)
-                                    panic!("expected trailers, received data")
-                                }
-                                StreamStage::Body(tx) => {
-                                    // TODO: we can get rid of that clone sometimes
-                                    let tx = tx.clone();
-                                    if flags.contains(DataFlags::EndStream) {
-                                        *stage = StreamStage::Done;
-                                    }
-                                    tx
-                                }
-                                StreamStage::Done => {
-                                    // TODO: proper error handling (stream error)
-                                    panic!("received data for stream after completion");
-                                }
+                        StreamStage::Trailers(..) => {
+                            // TODO: proper error handling (stream error)
+                            panic!("expected trailers, received data")
+                        }
+                        StreamStage::Body(tx) => {
+                            // TODO: we can get rid of that clone sometimes
+                            let tx = tx.clone();
+                            if flags.contains(DataFlags::EndStream) {
+                                *stage = StreamStage::Done;
                             }
-                        };
-
-                        if body_tx
-                            .send(Ok(PieceOrTrailers::Piece(payload.into())))
-                            .await
-                            .is_err()
-                        {
-                            warn!("TODO: The body is being ignored, we should reset the stream");
+                            tx
+                        }
+                        StreamStage::Done => {
+                            // TODO: proper error handling (stream error)
+                            panic!("received data for stream after completion");
                         }
                     }
-                    FrameType::Headers(flags) => {
-                        // TODO: if we're shutting down, ignore streams higher
-                        // than the last one we accepted.
+                };
 
-                        if frame.stream_id.is_server_initiated() {
-                            self.send_goaway(H2ConnectionError::ClientSidShouldBeOdd)
-                                .await;
-                            return Ok(());
-                        }
+                if body_tx
+                    .send(Ok(PieceOrTrailers::Piece(payload.into())))
+                    .await
+                    .is_err()
+                {
+                    warn!("TODO: The body is being ignored, we should reset the stream");
+                }
+            }
+            FrameType::Headers(flags) => {
+                // TODO: if we're shutting down, ignore streams higher
+                // than the last one we accepted.
 
-                        if frame.stream_id < self.state.last_stream_id {
-                            self.send_goaway(H2ConnectionError::ClientSidShouldBeIncreasing)
-                                .await;
-                        }
-                        self.state.last_stream_id = frame.stream_id;
+                if frame.stream_id.is_server_initiated() {
+                    self.send_goaway(H2ConnectionError::ClientSidShouldBeOdd)
+                        .await;
+                    return Ok(());
+                }
 
-                        let padding_length = if flags.contains(HeadersFlags::Padded) {
-                            if payload.is_empty() {
-                                self.send_goaway(H2ConnectionError::PaddedFrameEmpty).await;
-                                return Ok(());
-                            }
+                if frame.stream_id < self.state.last_stream_id {
+                    self.send_goaway(H2ConnectionError::ClientSidShouldBeIncreasing)
+                        .await;
+                }
+                self.state.last_stream_id = frame.stream_id;
 
-                            let padding_length_roll;
-                            (padding_length_roll, payload) = payload.split_at(1);
-                            padding_length_roll[0] as usize
-                        } else {
-                            0
-                        };
-
-                        if flags.contains(HeadersFlags::Priority) {
-                            let pri_spec;
-                            (payload, pri_spec) = PrioritySpec::parse(payload)
-                                .finish()
-                                .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
-                            debug!(exclusive = %pri_spec.exclusive, stream_dependency = ?pri_spec.stream_dependency, weight = %pri_spec.weight, "received priority, exclusive");
-
-                            if pri_spec.stream_dependency == frame.stream_id {
-                                self.send_goaway(H2ConnectionError::HeadersInvalidPriority {
-                                    stream_id: frame.stream_id,
-                                })
-                                .await;
-                                return Ok(());
-                            }
-                        }
-
-                        if padding_length > 0 {
-                            if payload.len() < padding_length {
-                                self.send_goaway(H2ConnectionError::PaddedFrameTooShort)
-                                    .await;
-                            }
-
-                            let at = payload.len() - padding_length;
-                            (payload, _) = payload.split_at(at);
-                        }
-
-                        let headers_data = HeadersData {
-                            end_stream: flags.contains(HeadersFlags::EndStream),
-                            fragments: smallvec![payload],
-                        };
-
-                        match self.state.streams.get_mut(&frame.stream_id) {
-                            Some(stage) => {
-                                debug!("Receiving trailers for stream {}", frame.stream_id);
-
-                                if !flags.contains(HeadersFlags::EndStream) {
-                                    todo!(
-                                            "handle connection error: trailers must have EndStream, this just looks like duplicate headers for stream {}",
-                                            frame.stream_id
-                                        );
-                                }
-
-                                let prev_stage = std::mem::replace(stage, StreamStage::Done);
-                                match prev_stage {
-                                    StreamStage::Body(body_tx) => {
-                                        *stage = StreamStage::Trailers(body_tx, headers_data);
-                                    }
-                                    // FIXME: that's a connection error
-                                    _ => unreachable!(),
-                                }
-                            }
-                            None => {
-                                debug!("Receiving headers for stream {}", frame.stream_id);
-                                self.state
-                                    .streams
-                                    .insert(frame.stream_id, StreamStage::Headers(headers_data));
-                            }
-                        }
-
-                        if flags.contains(HeadersFlags::EndHeaders) {
-                            self.end_headers(frame.stream_id).await;
-                        } else {
-                            debug!(
-                                "expecting more headers/trailers for stream {}",
-                                frame.stream_id
-                            );
-                            self.continuation_state =
-                                ContinuationState::ContinuingHeaders(frame.stream_id);
-                        }
-                    }
-                    FrameType::Priority => {
-                        let pri_spec = match PrioritySpec::parse(payload) {
-                            Ok((_rest, pri_spec)) => pri_spec,
-                            Err(e) => {
-                                todo!("handle connection error: invalid priority frame {e}")
-                            }
-                        };
-                        debug!(?pri_spec, "received priority frame");
-
-                        if pri_spec.stream_dependency == frame.stream_id {
-                            self.send_goaway(H2ConnectionError::HeadersInvalidPriority {
-                                stream_id: frame.stream_id,
-                            })
-                            .await;
-                            return Ok(());
-                        }
-                    }
-                    FrameType::RstStream => todo!("implement RstStream"),
-                    FrameType::Settings(s) => {
-                        if s.contains(SettingsFlags::Ack) {
-                            debug!("Peer has acknowledged our settings, cool");
-                        } else {
-                            // TODO: actually apply settings
-                            let (_, settings) = Settings::parse(payload)
-                                .finish()
-                                .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
-                            let new_max_header_table_size = settings.header_table_size;
-                            debug!(?settings, "Received settings");
-                            self.state.peer_settings = settings;
-
-                            if self
-                                .ev_tx
-                                .send(H2ConnEvent::AcknowledgeSettings {
-                                    new_max_header_table_size,
-                                })
-                                .await
-                                .is_err()
-                            {
-                                return Err(eyre::eyre!(
-                                    "could not send H2 acknowledge settings event"
-                                ));
-                            }
-                        }
-                    }
-                    FrameType::PushPromise => {
-                        self.send_goaway(H2ConnectionError::ClientSentPushPromise)
-                            .await;
+                let padding_length = if flags.contains(HeadersFlags::Padded) {
+                    if payload.is_empty() {
+                        self.send_goaway(H2ConnectionError::PaddedFrameEmpty).await;
                         return Ok(());
                     }
-                    FrameType::Ping(flags) => {
-                        if frame.stream_id != StreamId::CONNECTION {
-                            todo!("handle connection error: ping frame with non-zero stream id");
-                        }
 
-                        if frame.len != 8 {
-                            todo!("handle connection error: ping frame with invalid length");
-                        }
+                    let padding_length_roll;
+                    (padding_length_roll, payload) = payload.split_at(1);
+                    padding_length_roll[0] as usize
+                } else {
+                    0
+                };
 
-                        if flags.contains(PingFlags::Ack) {
-                            // TODO: check that payload matches the one we sent?
+                if flags.contains(HeadersFlags::Priority) {
+                    let pri_spec;
+                    (payload, pri_spec) = PrioritySpec::parse(payload)
+                        .finish()
+                        .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
+                    debug!(exclusive = %pri_spec.exclusive, stream_dependency = ?pri_spec.stream_dependency, weight = %pri_spec.weight, "received priority, exclusive");
 
-                            debug!("received ping ack");
-                            return Ok(());
-                        }
-
-                        if self.ev_tx.send(H2ConnEvent::Ping(payload)).await.is_err() {
-                            return Err(eyre::eyre!("could not send H2 ping event"));
-                        }
-                    }
-                    FrameType::GoAway => todo!(),
-                    FrameType::WindowUpdate => {
-                        debug!("ignoring window update");
-                    }
-                    FrameType::Continuation(_flags) => {
-                        self.send_goaway(H2ConnectionError::UnexpectedContinuationFrame {
+                    if pri_spec.stream_dependency == frame.stream_id {
+                        self.send_goaway(H2ConnectionError::HeadersInvalidPriority {
                             stream_id: frame.stream_id,
                         })
                         .await;
-                    }
-                    FrameType::Unknown(ft) => {
-                        trace!(
-                            "ignoring unknown frame with type 0x{:x}, flags 0x{:x}",
-                            ft.ty,
-                            ft.flags
-                        );
-                    }
-                }
-            }
-            ContinuationState::ContinuingHeaders(expected_stream_id) => {
-                match frame.frame_type {
-                    FrameType::Continuation(flags) => {
-                        if frame.stream_id != expected_stream_id {
-                            self.send_goaway(H2ConnectionError::ExpectedContinuationForStream {
-                                stream_id: expected_stream_id,
-                                continuation_stream_id: frame.stream_id,
-                            })
-                            .await;
-                            return Ok(());
-                        }
-
-                        // unwrap rationale: we just checked that this is a
-                        // continuation of a stream we've already learned about.
-                        let ss = self.state.streams.get_mut(&frame.stream_id).unwrap();
-                        match ss {
-                            StreamStage::Headers(data) | StreamStage::Trailers(_, data) => {
-                                data.fragments.push(payload);
-                            }
-                            _ => {
-                                // FIXME: store `HeadersData` in
-                                // `ContinuationState` directly so this
-                                // branch doesn't even exist.
-                                unreachable!()
-                            }
-                        }
-
-                        if flags.contains(ContinuationFlags::EndHeaders) {
-                            self.end_headers(frame.stream_id).await;
-                        } else {
-                            debug!(
-                                "expecting more headers/trailers for stream {}",
-                                frame.stream_id
-                            );
-                        }
-                    }
-                    other => {
-                        self.send_goaway(H2ConnectionError::ExpectedContinuationFrame {
-                            stream_id: expected_stream_id,
-                            frame_type: other,
-                        })
-                        .await;
                         return Ok(());
                     }
                 }
+
+                if padding_length > 0 {
+                    if payload.len() < padding_length {
+                        self.send_goaway(H2ConnectionError::PaddedFrameTooShort)
+                            .await;
+                    }
+
+                    let at = payload.len() - padding_length;
+                    (payload, _) = payload.split_at(at);
+                }
+
+                let headers_data = HeadersData {
+                    end_stream: flags.contains(HeadersFlags::EndStream),
+                    fragments: smallvec![payload],
+                };
+
+                match self.state.streams.get_mut(&frame.stream_id) {
+                    Some(stage) => {
+                        debug!("Receiving trailers for stream {}", frame.stream_id);
+
+                        if !flags.contains(HeadersFlags::EndStream) {
+                            todo!(
+                                            "handle connection error: trailers must have EndStream, this just looks like duplicate headers for stream {}",
+                                            frame.stream_id
+                                        );
+                        }
+
+                        let prev_stage = std::mem::replace(stage, StreamStage::Done);
+                        match prev_stage {
+                            StreamStage::Body(body_tx) => {
+                                *stage = StreamStage::Trailers(body_tx, headers_data);
+                            }
+                            // FIXME: that's a connection error
+                            _ => unreachable!(),
+                        }
+                    }
+                    None => {
+                        debug!("Receiving headers for stream {}", frame.stream_id);
+                        self.state
+                            .streams
+                            .insert(frame.stream_id, StreamStage::Headers(headers_data));
+                    }
+                }
+
+                if flags.contains(HeadersFlags::EndHeaders) {
+                    self.end_headers(frame.stream_id).await;
+                } else {
+                    debug!(
+                        "expecting more headers/trailers for stream {}",
+                        frame.stream_id
+                    );
+                    self.continuation_state = ContinuationState::ContinuingHeaders(frame.stream_id);
+                }
+            }
+            FrameType::Priority => {
+                let pri_spec = match PrioritySpec::parse(payload) {
+                    Ok((_rest, pri_spec)) => pri_spec,
+                    Err(e) => {
+                        todo!("handle connection error: invalid priority frame {e}")
+                    }
+                };
+                debug!(?pri_spec, "received priority frame");
+
+                if pri_spec.stream_dependency == frame.stream_id {
+                    self.send_goaway(H2ConnectionError::HeadersInvalidPriority {
+                        stream_id: frame.stream_id,
+                    })
+                    .await;
+                    return Ok(());
+                }
+            }
+            FrameType::RstStream => todo!("implement RstStream"),
+            FrameType::Settings(s) => {
+                if s.contains(SettingsFlags::Ack) {
+                    debug!("Peer has acknowledged our settings, cool");
+                } else {
+                    // TODO: actually apply settings
+                    let (_, settings) = Settings::parse(payload)
+                        .finish()
+                        .map_err(|err| eyre::eyre!("parsing error: {err:?}"))?;
+                    let new_max_header_table_size = settings.header_table_size;
+                    debug!(?settings, "Received settings");
+                    self.state.peer_settings = settings;
+
+                    if self
+                        .ev_tx
+                        .send(H2ConnEvent::AcknowledgeSettings {
+                            new_max_header_table_size,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        return Err(eyre::eyre!("could not send H2 acknowledge settings event"));
+                    }
+                }
+            }
+            FrameType::PushPromise => {
+                self.send_goaway(H2ConnectionError::ClientSentPushPromise)
+                    .await;
+                return Ok(());
+            }
+            FrameType::Ping(flags) => {
+                if frame.stream_id != StreamId::CONNECTION {
+                    todo!("handle connection error: ping frame with non-zero stream id");
+                }
+
+                if frame.len != 8 {
+                    todo!("handle connection error: ping frame with invalid length");
+                }
+
+                if flags.contains(PingFlags::Ack) {
+                    // TODO: check that payload matches the one we sent?
+
+                    debug!("received ping ack");
+                    return Ok(());
+                }
+
+                if self.ev_tx.send(H2ConnEvent::Ping(payload)).await.is_err() {
+                    return Err(eyre::eyre!("could not send H2 ping event"));
+                }
+            }
+            FrameType::GoAway => todo!(),
+            FrameType::WindowUpdate => match self.state.streams.get_mut(&frame.stream_id) {
+                Some(_ss) => {
+                    todo!("handle window update for stream {}", frame.stream_id)
+                }
+                None => {
+                    self.send_goaway(H2ConnectionError::WindowUpdateForUnknownStream {
+                        stream_id: frame.stream_id,
+                    })
+                    .await;
+                }
+            },
+            FrameType::Continuation(_flags) => {
+                self.send_goaway(H2ConnectionError::UnexpectedContinuationFrame {
+                    stream_id: frame.stream_id,
+                })
+                .await;
+            }
+            FrameType::Unknown(ft) => {
+                trace!(
+                    "ignoring unknown frame with type 0x{:x}, flags 0x{:x}",
+                    ft.ty,
+                    ft.flags
+                );
             }
         }
 
+        Ok(())
+    }
+
+    async fn process_continuation_frame(
+        &mut self,
+        frame: Frame,
+        payload: Roll,
+        expected_stream_id: StreamId,
+    ) -> eyre::Result<()> {
+        let flags = match frame.frame_type {
+            FrameType::Continuation(flags) => flags,
+            other => {
+                self.send_goaway(H2ConnectionError::ExpectedContinuationFrame {
+                    stream_id: expected_stream_id,
+                    frame_type: other,
+                })
+                .await;
+                return Ok(());
+            }
+        };
+
+        if frame.stream_id != expected_stream_id {
+            self.send_goaway(H2ConnectionError::ExpectedContinuationForStream {
+                stream_id: expected_stream_id,
+                continuation_stream_id: frame.stream_id,
+            })
+            .await;
+            return Ok(());
+        }
+
+        // unwrap rationale: we just checked that this is a
+        // continuation of a stream we've already learned about.
+        let ss = self.state.streams.get_mut(&frame.stream_id).unwrap();
+        match ss {
+            StreamStage::Headers(data) | StreamStage::Trailers(_, data) => {
+                data.fragments.push(payload);
+            }
+            _ => {
+                // FIXME: store `HeadersData` in
+                // `ContinuationState` directly so this
+                // branch doesn't even exist.
+                unreachable!()
+            }
+        }
+
+        if flags.contains(ContinuationFlags::EndHeaders) {
+            self.end_headers(frame.stream_id).await;
+        } else {
+            debug!(
+                "expecting more headers/trailers for stream {}",
+                frame.stream_id
+            );
+        }
         Ok(())
     }
 
@@ -1030,6 +1050,9 @@ enum H2ConnectionError {
     #[error("client sent a push promise frame, clients aren't allowed to do that, cf. RFC9113 section 8.4")]
     ClientSentPushPromise,
 
+    #[error("received window update for unknown stream {stream_id}")]
+    WindowUpdateForUnknownStream { stream_id: StreamId },
+
     #[error("other error: {0:?}")]
     Other(#[from] eyre::Report),
 }
@@ -1051,6 +1074,7 @@ impl H2ConnectionError {
             UnexpectedContinuationFrame { .. } => Code::ProtocolError,
             ClientSentPushPromise => Code::ProtocolError,
             CompressionError(_) => Code::CompressionError,
+            WindowUpdateForUnknownStream { .. } => Code::ProtocolError,
             Other(_) => Code::InternalError,
         }
     }

--- a/crates/fluke/src/h2/server.rs
+++ b/crates/fluke/src/h2/server.rs
@@ -660,7 +660,7 @@ impl<D: ServerDriver + 'static> H2ReadContext<D> {
                 }
                 _ => match self.state.streams.get_mut(&frame.stream_id) {
                     Some(_ss) => {
-                        todo!("handle window update for stream {}", frame.stream_id)
+                        debug!("TODO: handle window update for stream {}", frame.stream_id)
                     }
                     None => {
                         self.send_goaway(H2ConnectionError::WindowUpdateForUnknownStream {


### PR DESCRIPTION
Aiming to fix `http2/5.1/3` (receiving WINDOW_UPDATE on an idle stream is a connection error) but just reducing indentation for now